### PR TITLE
修正类常量未加self::错误

### DIFF
--- a/lib/HttpClient.class.php
+++ b/lib/HttpClient.class.php
@@ -120,7 +120,7 @@ class HttpConn
 		if ($realClose === true)
 		{
 			HttpClient::debug('close conn \'', $this->conn, '\': ', $this->sock);
-			$this->flag &= ~FLAG_OPENED;
+			$this->flag &= ~self::FLAG_OPENED;
 			@fclose($this->sock);
 			$this->delSockRef();
 			$this->sock = false;


### PR DESCRIPTION
line:127 类常量未使用self::前缀, 未定义常量错误.
